### PR TITLE
Switch log parser to syslog format

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -30,8 +30,11 @@ class IntegrationTest(TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             log_path = Path(tmpdir) / "test.log"
             lines = [
-                "1.1.1.1 - - [01/Jan/2023:00:00:00 +0000] \"GET /etc/passwd HTTP/1.1\" 404 0 \"-\" \"nmap\" resp_time:2",
-                "normal log"
+                (
+                    '<34>Oct 11 22:14:15 host sshd[123]: Failed password for invalid user '
+                    'root from 1.1.1.1 port 22'
+                ),
+                "normal log",
             ]
             log_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 

--- a/tests/test_log_parser.py
+++ b/tests/test_log_parser.py
@@ -3,17 +3,22 @@ from lms_log_analyzer.src import log_parser
 from lms_log_analyzer.src.utils import LRUCache
 
 class TestLogParser(unittest.TestCase):
-    def test_parse_status(self):
-        line = '127.0.0.1 - - [01/Jan/2023:00:00:00 +0000] "GET / HTTP/1.1" 404 123'
-        self.assertEqual(log_parser.parse_status(line), 404)
-        self.assertEqual(log_parser.parse_status('no status'), 0)
-
-    def test_response_time(self):
-        self.assertAlmostEqual(log_parser.response_time('resp_time:1.23'), 1.23)
-        self.assertEqual(log_parser.response_time('foo'), 0.0)
+    def test_parse_syslog_line(self):
+        line = (
+            '<34>Oct 11 22:14:15 host sshd[123]: Failed password for invalid user '
+            'root from 1.1.1.1 port 22'
+        )
+        parsed = log_parser.parse_syslog_line(line)
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed["severity"], "crit")
+        self.assertEqual(parsed["facility"], "auth")
+        self.assertIn("Failed password", parsed["msg"])
 
     def test_fast_score(self):
-        line = '1.1.1.1 - - [01/Jan/2023:00:00:00 +0000] "GET /etc/passwd HTTP/1.1" 404 0 "-" "nmap" resp_time:2'
+        line = (
+            '<34>Oct 11 22:14:15 host sshd[123]: Failed password for invalid user '
+            'root from 1.1.1.1 port 22'
+        )
         score = log_parser.fast_score(line)
         self.assertAlmostEqual(score, 0.9, places=2)
 


### PR DESCRIPTION
## Summary
- update `log_parser` to parse syslog messages via regex
- adjust heuristic scoring based on severity, facility and keywords
- update suspicious keyword list for syslog context
- adapt unit and integration tests for syslog parser

## Testing
- `pip install requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae2ebd69c8320b12c27df41cc78a3