### PR TITLE
Refactor Wazuh optional flow

### DIFF
--- a/lms_log_analyzer/config.py
+++ b/lms_log_analyzer/config.py
@@ -15,8 +15,9 @@ VECTOR_DB_PATH = DATA_DIR / "faiss.index"
 # 儲存每筆向量對應的歷史案例（包含原始日誌與分析結果）
 CASE_DB_PATH = DATA_DIR / "cases.json"
 
-# 日誌與輸出結果的路徑，預設位於 ``/var/log``，亦可透過環境變數覆寫。
-DEFAULT_TARGET_LOG_DIR = "/var/log/LMS_LOG"
+# 日誌與輸出結果的路徑。預設掃描 ``/var/log`` 下的系統日誌，
+# 亦可透過環境變數覆寫。
+DEFAULT_TARGET_LOG_DIR = "/var/log"
 DEFAULT_ANALYSIS_OUTPUT_FILE = "/var/log/analyzer_results.json"
 DEFAULT_OPERATIONAL_LOG_FILE = BASE_DIR / "analyzer_script.log"
 


### PR DESCRIPTION
## Summary
- decouple Wazuh from core processing
- default to scanning `/var/log`
- sample high scoring log lines first then optionally query Wazuh

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b158011d883209af1673924818ea9